### PR TITLE
feat: replace ssh-private-key with ssh-private-keys and expected input is json with array of {name, key} entries.

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,46 +1,31 @@
 on: [ push, pull_request ]
 
 jobs:
-    deployment_keys_demo:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        runs-on: ${{ matrix.os }}
-        steps:
-            -   uses: actions/checkout@v3
-            -   name: Setup key
-                uses: ./
-                with:
-                    ssh-private-key: |
-                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
-                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
-            -   run: |
-                    git clone https://github.com/mpdude/test-1.git test-1-http
-                    git clone git@github.com:mpdude/test-1.git test-1-git
-                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
-                    git clone https://github.com/mpdude/test-2.git test-2-http
-                    git clone git@github.com:mpdude/test-2.git test-2-git
-                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
-
-    docker_demo:
-        runs-on: ubuntu-latest
-        container:
-            image: ubuntu:latest
-        steps:
-            -   uses: actions/checkout@v3
-            -   run: apt update && apt install -y openssh-client git
-            -   name: Setup key
-                uses: ./
-                with:
-                    ssh-private-key: |
-                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
-                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
-            -   run: |
-                    git clone https://github.com/mpdude/test-1.git test-1-http
-                    git clone git@github.com:mpdude/test-1.git test-1-git
-                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
-                    git clone https://github.com/mpdude/test-2.git test-2-http
-                    git clone git@github.com:mpdude/test-2.git test-2-git
-                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
-
+  vmo_deployment_keys_demo:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install openssh
+        run: which openssh-client || (apt-get update && apt-get install -y openssh-client git > /dev/null)
+      -   uses: actions/checkout@v3
+      -   name: Setup key
+          uses: ./
+          with:
+            ssh-private-keys: |
+              [
+                {
+                  "name": "git@github.com:vaimo/vsf2_ext-lru-cache-driver.git",
+                  "key": "${{ secrets.TEST_1_DEPLOY_KEY }}"
+                },
+                {
+                  "name": "git@github.com:mpdude/test-2.git",
+                  "key": "${{ secrets.TEST_2_DEPLOY_KEY }}"
+                }
+              ]
+      -   run: |
+            git clone https://github.com/vaimo/vsf2_ext-lru-cache-driver.git test-1-http
+            git clone git@github.com:vaimo/vsf2_ext-lru-cache-driver.git test-1-git
+            git clone ssh://git@github.com/vaimo/vsf2_ext-lru-cache-driver.git test-1-git-ssh

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -2,15 +2,21 @@ on: [ push, pull_request ]
 
 jobs:
   vmo_deployment_keys_demo:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
     steps:
-      - name: Install openssh
-        run: which openssh-client || (apt-get update && apt-get install -y openssh-client git > /dev/null)
       -   uses: actions/checkout@v3
+      -   run: apt update && apt install -y openssh-client git curl
+      -   if: ${{ env.ACT }}
+          name: Hack container for local development
+          run: |
+            curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+            apt-get install -y nodejs
+      -   name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: '16.x'
       -   name: Setup key
           uses: ./
           with:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,7 +11,7 @@ jobs:
       -   if: ${{ env.ACT }}
           name: Hack container for local development
           run: |
-            curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+            curl -fsSL https://deb.nodesource.com/setup_16.x | bash -s
             apt-get install -y nodejs
       -   name: Setup node
           uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -39,8 +39,14 @@ jobs:
             # Make sure the @v0.6.0 matches the current version of the
             # action 
             - uses: webfactory/ssh-agent@v0.6.0
-              with:
-                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+            with:
+              ssh-private-keys: |
+                [
+                  {
+                    "name": "git@github.com:vendor/repo-1.git",
+                    "key": "${{ secrets.SSH_PRIVATE_KEY }}"
+                  }
+                ]
             - ... other steps
 ```
 5. If, for some reason, you need to change the location of the SSH agent socket, you can use the `ssh-auth-sock` input to provide a path.
@@ -55,10 +61,21 @@ You can set up different keys as different secrets and pass them all to the acti
 # ... contens as before
             - uses: webfactory/ssh-agent@v0.6.0
               with:
-                  ssh-private-key: |
-                        ${{ secrets.FIRST_KEY }}
-                        ${{ secrets.NEXT_KEY }}
-                        ${{ secrets.ANOTHER_KEY }}
+                  ssh-private-keys: |
+                    [
+                        {
+                          "name": "git@github.com:vendor/repo-1.git",
+                          "key": "${{ secrets.FIRST_KEY }}"
+                        },
+                        {
+                          "name": "git@github.com:vendor/repo-2.git",
+                          "key": "${{ secrets.NEXT_KEY }}"
+                        },
+                        {
+                          "name": "git@github.com:vendor/repo-3.git",
+                          "key": "${{ secrets.ANOTHER_KEY }}"
+                        }
+                    ]
 ```
 
 The `ssh-agent` will load all of the keys and try each one in order when establishing SSH connections.

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,10 @@
-name: 'webfactory/ssh-agent'
+name: 'vaimo/webfactory-ssh-agent'
 description: 'Run `ssh-agent` and load an SSH key to access other private repositories'
 inputs:
-    ssh-private-key:
-        description: 'Private SSH key to register in the SSH agent'
+    ssh-private-keys:
+        description: 'Private SSH key(s) to register in the SSH agent'
         required: true
+        default: 'GitHub'
     ssh-auth-sock:
         description: 'Where to place the SSH Agent auth socket'
     log-public-key:

--- a/dist/index.js
+++ b/dist/index.js
@@ -322,17 +322,19 @@ const core = __webpack_require__(470);
 const child_process = __webpack_require__(129);
 const fs = __webpack_require__(747);
 const crypto = __webpack_require__(417);
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = __webpack_require__(972);
+const { homePath, sshAgentCmd, sshAddCmd, sshKeyGenCmd, gitCmd } = __webpack_require__(972);
 
 try {
-    const privateKey = core.getInput('ssh-private-key');
+    const privateKeys = core.getInput('ssh-private-keys');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
 
-    if (!privateKey) {
-        core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");
+    if (!privateKeys) {
+        core.setFailed("The ssh-private-keys Array{name, key} argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");
 
         return;
     }
+
+    const privateKeysData = JSON.parse(privateKeys.replaceAll("\n", ""))
 
     const homeSsh = homePath + '/.ssh';
 
@@ -359,47 +361,58 @@ try {
         }
     });
 
-    console.log("Adding private key(s) to agent");
+    console.log("Adding private key(s) to agent and Configuring deployment key(s)");
 
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
-        child_process.execFileSync(sshAddCmd, ['-'], { input: key.trim() + "\n" });
+    privateKeysData.forEach(async ({ name, key }) => {
+        const repoName = name.trim();
+        let privateKey = key.trim();
+
+        privateKey = privateKey.replace(/(KEY-----)(...)/, '$1\n$2')
+                  .replace(/(...)(-----END )/, '$1\n$2') + "\n"
+
+        child_process.execFileSync(sshAddCmd, ['-'], { input: privateKey });
+
+        const sha256 = crypto.createHash('sha256').update(privateKey).digest('hex');
+        const filename = `${homeSsh}/key-${sha256}`
+
+        await fs.writeFile(filename, privateKey, { }, (err) => {
+            if (err) {
+                console.log(err)
+                return
+            }
+
+            fs.chmodSync(filename, '600')
+
+            const parts = repoName.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
+
+            if (!parts) {
+                if (logPublicKey) {
+                    console.log(`Comment for name '${repoName}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
+                }
+
+                return;
+            }
+
+            const ownerAndRepo = parts[1].replace(/\.git$/, '');
+
+            child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
+            child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
+            child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+
+            const sshConfig = `\nHost key-${sha256}.github.com\n`
+                              + `    HostName github.com\n`
+                              + `    IdentityFile ${filename}\n`
+                              + `    IdentitiesOnly yes\n`;
+
+            fs.appendFileSync(`${homeSsh}/config`, sshConfig);
+
+            console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
+        })
     });
 
     console.log("Key(s) added:");
 
     child_process.execFileSync(sshAddCmd, ['-l'], { stdio: 'inherit' });
-
-    console.log('Configuring deployment key(s)');
-
-    child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
-
-        if (!parts) {
-            if (logPublicKey) {
-              console.log(`Comment for (public) key '${key}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
-            }
-            return;
-        }
-
-        const sha256 = crypto.createHash('sha256').update(key).digest('hex');
-        const ownerAndRepo = parts[1].replace(/\.git$/, '');
-
-        fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
-
-        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
-
-        const sshConfig = `\nHost key-${sha256}.github.com\n`
-                              + `    HostName github.com\n`
-                              + `    IdentityFile ${homeSsh}/key-${sha256}\n`
-                              + `    IdentitiesOnly yes\n`;
-
-        fs.appendFileSync(`${homeSsh}/config`, sshConfig);
-
-        console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
-    });
-
 } catch (error) {
 
     if (error.code == 'ENOENT') {


### PR DESCRIPTION
### Background
Module https://github.com/webfactory/ssh-agent exports public keys from private keys under `.ssh/` folder and depends only on ssh-agent behaviour on selecting correct cert.

When trying to pass to docker build with action which doesn't support forwarded ssh-agent then while trying to use generated key-* files then we get `invalid format` - with PEM or non-PEM / reason is that public key can not be used for ssh-git authentication.

### Description
With this change we export all passed private keys and use new format for input - Array of {name, key} where `name` should be "`git@github.com:owner/repo.git`" and we will use this instead of trying to extract from public key.

### Example usage

```
      - name: Register SSH keys
        uses: vaimo/webfactory-ssh-agent-github@feature/json-private-keys
        with:
          ssh-private-keys: |
            [
              {
                "name": "git@github.com:vaimo/vsf2--test-package.git",
                "key": "${{ secrets.VAIMO_PRIVATE_REPO_TEST }}"
              },
              {
                "name": "git@github.com:vaimo/vsf2_ext-lru-cache-driver",
                "key": "${{ secrets.VAIMO_PRIVATE_REPO_LRU_DRV }}"
              }
            ]
```