### PR TITLE
feat: replace ssh-private-key with ssh-private-keys and expected input is json with {name: key} entries.

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,46 +1,31 @@
 on: [ push, pull_request ]
 
 jobs:
-    deployment_keys_demo:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        runs-on: ${{ matrix.os }}
-        steps:
-            -   uses: actions/checkout@v3
-            -   name: Setup key
-                uses: ./
-                with:
-                    ssh-private-key: |
-                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
-                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
-            -   run: |
-                    git clone https://github.com/mpdude/test-1.git test-1-http
-                    git clone git@github.com:mpdude/test-1.git test-1-git
-                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
-                    git clone https://github.com/mpdude/test-2.git test-2-http
-                    git clone git@github.com:mpdude/test-2.git test-2-git
-                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
-
-    docker_demo:
-        runs-on: ubuntu-latest
-        container:
-            image: ubuntu:latest
-        steps:
-            -   uses: actions/checkout@v3
-            -   run: apt update && apt install -y openssh-client git
-            -   name: Setup key
-                uses: ./
-                with:
-                    ssh-private-key: |
-                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
-                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
-            -   run: |
-                    git clone https://github.com/mpdude/test-1.git test-1-http
-                    git clone git@github.com:mpdude/test-1.git test-1-git
-                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
-                    git clone https://github.com/mpdude/test-2.git test-2-http
-                    git clone git@github.com:mpdude/test-2.git test-2-git
-                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
-
+  vmo_deployment_keys_demo:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+    steps:
+      -   uses: actions/checkout@v3
+      -   run: apt update && apt install -y openssh-client git curl
+      -   if: ${{ env.ACT }}
+          name: Hack container for local development
+          run: |
+            curl -fsSL https://deb.nodesource.com/setup_16.x | bash -s
+            apt-get install -y nodejs
+      -   name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: '16.x'
+      -   name: Setup key
+          uses: ./
+          with:
+            ssh-private-keys: |
+              {
+                "git@github.com:vaimo/vsf2_ext-lru-cache-driver.git": "${{ secrets.TEST_1_DEPLOY_KEY }}",
+                "git@github.com:mpdude/test-2.git": "${{ secrets.TEST_2_DEPLOY_KEY }}"
+              }
+      -   run: |
+            git clone https://github.com/vaimo/vsf2_ext-lru-cache-driver.git test-1-http
+            git clone git@github.com:vaimo/vsf2_ext-lru-cache-driver.git test-1-git
+            git clone ssh://git@github.com/vaimo/vsf2_ext-lru-cache-driver.git test-1-git-ssh

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
         required: false
         default: true
 runs:
-    using: 'node16'
+    using: 'node20'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
     post-if: 'always()'

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,10 @@
-name: 'webfactory/ssh-agent'
+name: 'vaimo/webfactory-ssh-agent'
 description: 'Run `ssh-agent` and load an SSH key to access other private repositories'
 inputs:
-    ssh-private-key:
-        description: 'Private SSH key to register in the SSH agent'
+    ssh-private-keys:
+        description: 'Private SSH key(s) to register in the SSH agent'
         required: true
+        default: 'GitHub'
     ssh-auth-sock:
         description: 'Where to place the SSH Agent auth socket'
     log-public-key:

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -292,13 +292,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.issueCommand = void 0;
+exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
+const uuid_1 = __webpack_require__(62);
 const utils_1 = __webpack_require__(82);
-function issueCommand(command, message) {
+function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -310,7 +311,22 @@ function issueCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueCommand = issueCommand;
+exports.issueFileCommand = issueFileCommand;
+function prepareKeyValueMessage(key, value) {
+    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+    const convertedValue = utils_1.toCommandValue(value);
+    // These should realistically never happen, but just in case someone finds a
+    // way to exploit uuid generation let's not allow keys or values that contain
+    // the delimiter.
+    if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+    }
+    if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+    }
+    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+}
+exports.prepareKeyValueMessage = prepareKeyValueMessage;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),
@@ -1668,7 +1684,6 @@ const file_command_1 = __webpack_require__(102);
 const utils_1 = __webpack_require__(82);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
-const uuid_1 = __webpack_require__(62);
 const oidc_utils_1 = __webpack_require__(742);
 /**
  * The code to exit an action
@@ -1698,20 +1713,9 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
-        if (name.includes(delimiter)) {
-            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-        }
-        if (convertedVal.includes(delimiter)) {
-            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-        }
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
+        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
     }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
+    command_1.issueCommand('set-env', { name }, convertedVal);
 }
 exports.exportVariable = exportVariable;
 /**
@@ -1729,7 +1733,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -1769,7 +1773,10 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    return inputs;
+    if (options && options.trimWhitespace === false) {
+        return inputs;
+    }
+    return inputs.map(input => input.trim());
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -1802,8 +1809,12 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
+    const filePath = process.env['GITHUB_OUTPUT'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
+    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
 }
 exports.setOutput = setOutput;
 /**
@@ -1932,7 +1943,11 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
+    const filePath = process.env['GITHUB_STATE'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
+    }
+    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
 }
 exports.saveState = saveState;
 /**

--- a/index.js
+++ b/index.js
@@ -2,17 +2,18 @@ const core = require('@actions/core');
 const child_process = require('child_process');
 const fs = require('fs');
 const crypto = require('crypto');
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = require('./paths.js');
+const { homePath, sshAgentCmd, sshAddCmd, sshKeyGenCmd, gitCmd } = require('./paths.js');
 
 try {
-    const privateKey = core.getInput('ssh-private-key');
-    const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
+    const privateKeys = core.getInput('ssh-private-keys', { required: true });
+    const logPublicKey = core.getBooleanInput('log-public-key');
 
-    if (!privateKey) {
-        core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");
-
-        return;
+    if (!privateKeys) {
+        throw new Error("The ssh-private-keys {name: key} argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.")
     }
+
+    console.debug(privateKeys.replaceAll("\n", ""))
+    const privateKeysData = JSON.parse(privateKeys.replaceAll("\n", ""))
 
     const homeSsh = homePath + '/.ssh';
 
@@ -29,7 +30,7 @@ try {
     const sshAgentArgs = (authSock && authSock.length > 0) ? ['-a', authSock] : [];
 
     // Extract auth socket path and agent pid and set them as job variables
-    child_process.execFileSync(sshAgentCmd, sshAgentArgs).toString().split("\n").forEach(function(line) {
+    child_process.execFileSync(sshAgentCmd, sshAgentArgs).toString().split("\n").forEach((line) => {
         const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(line);
 
         if (matches && matches.length > 0) {
@@ -39,52 +40,71 @@ try {
         }
     });
 
-    console.log("Adding private key(s) to agent");
+    console.log("Adding private key(s) to agent and Configuring deployment key(s)");
 
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
-        child_process.execFileSync(sshAddCmd, ['-'], { input: key.trim() + "\n" });
+    Object.keys(privateKeysData).forEach(async (name) => {
+        const repoName = name.trim();
+        let privateKey = privateKeysData[name].trim();
+
+        if (!privateKey) {
+            throw new Error('privateKey is empty for "' + name + '"')
+        }
+
+        privateKey = privateKey.replace(/(KEY-----)(...)/, '$1\n$2')
+                  .replace(/(...)(-----END )/, '$1\n$2') + "\n"
+
+        child_process.execFileSync(sshAddCmd, ['-'], { input: privateKey });
+
+        const sha256 = crypto.createHash('sha256').update(privateKey).digest('hex');
+        const filename = `${homeSsh}/key-${sha256}`
+
+        await fs.writeFile(filename, privateKey, { }, (err) => {
+            if (err) {
+                console.log(err)
+                return
+            }
+
+            fs.chmodSync(filename, '600')
+
+            const parts = repoName.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
+
+            if (!parts) {
+                if (logPublicKey) {
+                    console.log(`Comment for name '${repoName}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
+                }
+
+                return;
+            }
+
+            const ownerAndRepo = parts[1].replace(/\.git$/, '');
+
+            child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
+            child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
+            child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+
+            const sshConfig = `\nHost key-${sha256}.github.com\n`
+                              + `    HostName github.com\n`
+                              + `    IdentityFile ${filename}\n`
+                              + `    IdentitiesOnly yes\n`;
+
+            fs.appendFileSync(`${homeSsh}/config`, sshConfig);
+
+            console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
+        })
     });
 
     console.log("Key(s) added:");
 
     child_process.execFileSync(sshAddCmd, ['-l'], { stdio: 'inherit' });
-
-    console.log('Configuring deployment key(s)');
-
-    child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
-
-        if (!parts) {
-            if (logPublicKey) {
-              console.log(`Comment for (public) key '${key}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
-            }
-            return;
-        }
-
-        const sha256 = crypto.createHash('sha256').update(key).digest('hex');
-        const ownerAndRepo = parts[1].replace(/\.git$/, '');
-
-        fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
-
-        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
-
-        const sshConfig = `\nHost key-${sha256}.github.com\n`
-                              + `    HostName github.com\n`
-                              + `    IdentityFile ${homeSsh}/key-${sha256}\n`
-                              + `    IdentitiesOnly yes\n`;
-
-        fs.appendFileSync(`${homeSsh}/config`, sshConfig);
-
-        console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
-    });
-
 } catch (error) {
 
-    if (error.code == 'ENOENT') {
+    if (error.code === 'ENOENT') {
         console.log(`The '${error.path}' executable could not be found. Please make sure it is on your PATH and/or the necessary packages are installed.`);
         console.log(`PATH is set to: ${process.env.PATH}`);
+    }
+
+    if (error.constructor && error.constructor.name === 'SyntaxError') {
+        console.error(`JSON parsing error on "ssh-private-keys" value: ${error.message}`);
     }
 
     core.setFailed(error.message);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "webfactory GmbH <info@webfactory.de>",
     "license": "MIT",
     "devDependencies": {
-        "@actions/core": "^1.9.1",
+        "@actions/core": "^1.10.0",
         "@zeit/ncc": "^0.20.5"
     },
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,32 +2,32 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.9.1":
-  "integrity" "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA=="
-  "resolved" "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz"
-  "version" "1.9.1"
+"@actions/core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.0.tgz#44551c3c71163949a2f06e94d9ca2157a0cfac4f"
+  integrity sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==
   dependencies:
     "@actions/http-client" "^2.0.1"
-    "uuid" "^8.3.2"
+    uuid "^8.3.2"
 
 "@actions/http-client@^2.0.1":
-  "integrity" "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw=="
-  "resolved" "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz"
-  "version" "2.0.1"
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz"
+  integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
   dependencies:
-    "tunnel" "^0.0.6"
+    tunnel "^0.0.6"
 
 "@zeit/ncc@^0.20.5":
-  "integrity" "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw=="
-  "resolved" "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz"
-  "version" "0.20.5"
+  version "0.20.5"
+  resolved "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz"
+  integrity sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==
 
-"tunnel@^0.0.6":
-  "integrity" "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-  "resolved" "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz"
-  "version" "0.0.6"
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
-"uuid@^8.3.2":
-  "integrity" "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-  "resolved" "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  "version" "8.3.2"
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
### Background
Module https://github.com/webfactory/ssh-agent exports public keys from private keys under `.ssh/` folder and depends only on ssh-agent behaviour on selecting correct cert.

When trying to pass to docker build with action which doesn't support forwarded ssh-agent then while trying to use generated key-* files then we get `invalid format` - with PEM or non-PEM / reason is that public key can not be used for ssh-git authentication.

### Description
With this change we export all passed private keys and use new format for input - object key should be "`git@github.com:owner/repo.git`" and we will use that one instead of trying to extract comment from public key where it potentially could be missing.

### Example usage

```
      - name: Register SSH keys
        uses: vaimo/webfactory-ssh-agent-github@feature/json-private-keys--v2
        with:
          ssh-private-keys: |
              {
                "git@github.com:vaimo/vsf2--test-package.git": "${{ secrets.VAIMO_PRIVATE_REPO_TEST }}",
                "git@github.com:vaimo/vsf2_ext-lru-cache-driver": "${{ secrets.VAIMO_PRIVATE_REPO_LRU_DRV }}"
              }
```